### PR TITLE
Fix nullish coalescing bug. Still need to make moar better

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -388,7 +388,9 @@ export function mergeLinterConfigs<
     ...pruneUndefined(configB),
     rules: { ...configA.rules, ...configB.rules },
     // TODO: fix this
-    ruleFiles: configB.ruleFiles ?? configA.ruleFiles,
+    ruleFiles: configB.ruleFiles?.length
+      ? configB.ruleFiles
+      : configA.ruleFiles,
     // ruleFiles: dedupe([
     //   ...(configA.ruleFiles ?? []),
     //   ...(configB.ruleFiles ?? [])


### PR DESCRIPTION
Current implementation has a bug - nullish coalescing will always return the empty array, not fallback to configA.ruleFiles.