### PR TITLE
add ability to supply custom dotenv config

### DIFF
--- a/bin/gptlint.ts
+++ b/bin/gptlint.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import 'dotenv/config'
+
+import '../src/dotenv-config.js'
 
 import { gracefulExit } from 'exit-hook'
 import plur from 'plur'

--- a/src/config.ts
+++ b/src/config.ts
@@ -180,6 +180,11 @@ export const LinterConfigSchema = z
         'An optional array of glob patterns for the files to process. If not specified, the configuration object applies to all files matched by any other configuration object.'
       ),
 
+    dotenvPath: z
+      .string()
+      .optional()
+      .describe('An optional custom path to the .env file'),
+
     ignores: z
       .array(z.string())
       .optional()

--- a/src/dotenv-config.ts
+++ b/src/dotenv-config.ts
@@ -1,0 +1,21 @@
+import path from 'node:path'
+
+import * as dotenv from 'dotenv'
+
+/**
+ * Dynamically import dotenv and configure it based on CLI arguments.
+ */
+const pathIndex = process.argv.indexOf('--dotenv-path') + 1
+let envPath = '.env'
+const configuredEnvPath = process.argv[pathIndex]
+
+if (
+  pathIndex &&
+  pathIndex < process.argv.length &&
+  typeof configuredEnvPath === 'string'
+) {
+  envPath = configuredEnvPath
+}
+
+const resolvedDotenvPath = path.resolve(process.cwd(), envPath)
+dotenv.config({ path: resolvedDotenvPath })

--- a/src/resolve-cli-config.ts
+++ b/src/resolve-cli-config.ts
@@ -74,6 +74,10 @@ export async function resolveLinterCLIConfig(
           type: String,
           description: 'Customize the path to the cache directory'
         },
+        dotenvPath: {
+          type: String,
+          description: 'Customize the path to the .env file'
+        },
         concurrency: {
           type: Number,
           description: 'Limits the maximum number of concurrent tasks'
@@ -189,6 +193,7 @@ export async function resolveLinterCLIConfig(
     files: files.length > 0 ? files : undefined,
     ignores: ignores.length > 0 ? ignores : undefined,
     ruleFiles: args.flags.rules.length > 0 ? args.flags.rules : undefined,
+    dotenvPath: args.flags.dotenvPath,
     linterOptions: {
       noInlineConfig: args.flags.noInlineConfig,
       earlyExit: args.flags.earlyExit,


### PR DESCRIPTION
This PR adds support for a custom `.env` config path to pass to `dotenv.config`.

Since I want this to run before everything else, I didn't import the resolved-cli-config, but wasn't sure if there was a cleaner way to do this than to simply grab the args directly.

Here's the output of `--help`
<img width="668" alt="image" src="https://github.com/gptlint/gptlint/assets/22401430/38e5859e-a3c2-444d-b3da-feab967dc43c">

and here's the output of `--print-config` for `tsx bin/gptlint.ts --dotenv-path .env.local --print-config`
<img width="698" alt="image" src="https://github.com/gptlint/gptlint/assets/22401430/8c6ff10a-c7d9-4b0f-b0c9-578dd7242e06">
